### PR TITLE
Add images and opening hours using the Yelp Fusion (v3) API.

### DIFF
--- a/app/clients.py
+++ b/app/clients.py
@@ -6,12 +6,17 @@ from factual import Factual
 from yelp.client import Client
 from yelp.oauth1_authenticator import Oauth1Authenticator
 
+from app.yelp3 import Yelp3Client
+
 with io.open('keys.local.json') as cred:
     creds = json.load(cred)
-    yelpCreds = creds["yelp"]
-    auth = Oauth1Authenticator(**yelpCreds)
-    yelpClient = Client(auth)
-    factualCreds = creds["factual"]
-    factualClient = Factual(factualCreds["key"], factualCreds["secret"])
+    _yelpCreds = creds["yelp"]
+    _auth = Oauth1Authenticator(**_yelpCreds)
+    yelpClient = Client(_auth)
+    _factualCreds = creds["factual"]
+    factualClient = Factual(_factualCreds["key"], _factualCreds["secret"])
     googleapikey = creds["googleapikey"]
 
+    _yelp3Creds = creds["yelp3"]
+    yelp3Client = Yelp3Client(_yelp3Creds["app_id"], _yelp3Creds["app_secret"])
+    yelp3Client.refreshAccessToken()

--- a/app/providers/yelp.py
+++ b/app/providers/yelp.py
@@ -1,13 +1,13 @@
 import re
 
-from app.clients import yelpClient
+from app.clients import yelp3Client
 from app.util import slug
 
 idPattern = re.compile("/([^/\?]*)(\?.*)?$")
 
 def resolve(idObj):
-    id = slug(idObj["url"])
+    key = slug(idObj["url"])
     params = {
       "lang": "en"
     }
-    return yelpClient.get_business(id, **params)
+    return yelp3Client.request("/businesses/%s" % key)

--- a/app/representation.py
+++ b/app/representation.py
@@ -1,25 +1,38 @@
 def venueRecord(biz, **details):
     # biz is the response object from the Yelp Search API
+    providers = {}
+    images = []
+    if "yelp" in details:
+      info = details["yelp"]
+      providers["yelp"] = {
+        "rating": biz.rating,
+        "reviewCount": biz.review_count,
+        "ratingMax": 5,
+        "description": biz.snippet_text,
+        "url": biz.url
+      }
+      images = images + info["photos"]
+
+    if "wikipedia" in details:
+      info = details["wikipedia"]
+      providers["wikipedia"] = {
+        "url": info.url,
+        "description": info.summary
+      }
+      images = images + info.images
+
     return {
-      "version": 1.0,
       "id": biz.id,
+      "name": biz.name,
       "coordinates": {
         "lat": biz.location.coordinate.latitude,
         "lon": biz.location.coordinate.longitude
       },
-      "images": [],
+      "images": images,
       "address": biz.location.display_address,
-
-      "pullQuote": biz.snippet_text,
-
-      "providers": {
-        "yelp": {
-          "rating": biz.rating,
-          "reviewCount": biz.review_count,
-          "ratingMax": 5,
-          "url": biz.url
-        }
-      }
+      "description": biz.snippet_text,
+      "providers": providers,
+      "version": 1.0
     }
 
 def createKey(biz):

--- a/app/representation.py
+++ b/app/representation.py
@@ -2,6 +2,7 @@ def venueRecord(biz, **details):
     # biz is the response object from the Yelp Search API
     providers = {}
     images = []
+    hours = []
     if "yelp" in details:
       info = details["yelp"]
       providers["yelp"] = {
@@ -12,6 +13,7 @@ def venueRecord(biz, **details):
         "url": biz.url
       }
       images = images + info["photos"]
+      hours = info["hours"][0]["open"]
 
     if "wikipedia" in details:
       info = details["wikipedia"]
@@ -24,6 +26,7 @@ def venueRecord(biz, **details):
     return {
       "id": biz.id,
       "name": biz.name,
+      "hours": hours,
       "coordinates": {
         "lat": biz.location.coordinate.latitude,
         "lon": biz.location.coordinate.longitude

--- a/app/yelp3.py
+++ b/app/yelp3.py
@@ -1,0 +1,32 @@
+from sanction import Client
+
+class Yelp3Client:
+    def __init__(self, client_id, client_secret):
+        self.client  = Client(
+          token_endpoint="https://api.yelp.com/oauth2/token", 
+          resource_endpoint="https://api.yelp.com/v3", 
+          client_id=client_id, 
+          client_secret=client_secret
+        )
+
+    def refreshAccessToken(self):
+        if self.client.access_token is not None:
+            from datetime import datetime, timedelta
+            from time import mktime
+            now = mktime(datetime.utcnow().timetuple())
+            if now <= self.client.token_expires:
+                return self.client.access_token  
+
+        self.client.request_token(grant_type="client_credentials")
+        return self.client.access_token
+
+    def request(self, endpoint):
+        access_token = self.refreshAccessToken()
+        return self.client.request(endpoint, 
+            method="GET", 
+            headers={'Authorization': 'Bearer {0}'.format(access_token)}
+        )
+
+
+
+

--- a/docs/yelp3_businesses_sample.json
+++ b/docs/yelp3_businesses_sample.json
@@ -1,0 +1,166 @@
+{
+  "rating": 4.5, 
+  "review_count": 10, 
+  "name": "49 Black Sand Beach", 
+  "phone": "+18088870531", 
+  "url": "https://www.yelp.com/biz/49-black-sand-beach-kamuela?adjust_creative=IsIDClmA95d_bteaxrfQSg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=IsIDClmA95d_bteaxrfQSg", 
+  "coordinates": {
+    "latitude": 19.9322810769081, 
+    "longitude": -155.878625437617
+  }, 
+  "hours": [
+    {
+      "hours_type": "REGULAR", 
+      "open": [], 
+      "is_open_now": false
+    }
+  ], 
+  "photos": [
+    "https://s3-media1.fl.yelpcdn.com/bphoto/PUutggfVVm64zjqY0MQxKQ/o.jpg", 
+    "https://s3-media2.fl.yelpcdn.com/bphoto/XklW__6AljuF9lCzmA0TWg/o.jpg", 
+    "https://s3-media4.fl.yelpcdn.com/bphoto/B6XajK-DwGe8aEGRctyKsQ/o.jpg"
+  ], 
+  "image_url": "https://s3-media2.fl.yelpcdn.com/bphoto/PUutggfVVm64zjqY0MQxKQ/o.jpg", 
+  "location": {
+    "city": "Kamuela", 
+    "country": "US", 
+    "address2": null, 
+    "address3": null, 
+    "state": "HI", 
+    "address1": "68-1107 Honokaope Pl", 
+    "zip_code": "96743"
+  }, 
+  "id": "49-black-sand-beach-kamuela", 
+  "categories": [
+    {
+      "alias": "beaches", 
+      "title": "Beaches"
+    }
+  ]
+}
+(env) 18:17:44 jhugman/yelp3 ~/workspaces/mozilla/prox/prox-server
+$ python -m samples.yelp-test
+{
+  "rating": 4.0, 
+  "review_count": 738, 
+  "name": "North India Restaurant", 
+  "phone": "+14153481234", 
+  "url": "https://www.yelp.com/biz/north-india-restaurant-san-francisco?adjust_creative=IsIDClmA95d_bteaxrfQSg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=IsIDClmA95d_bteaxrfQSg", 
+  "price": "$$", 
+  "coordinates": {
+    "latitude": 37.787789124691, 
+    "longitude": -122.399305736113
+  }, 
+  "hours": [
+    {
+      "hours_type": "REGULAR", 
+      "open": [
+        {
+          "start": "1000", 
+          "end": "2300", 
+          "day": 0, 
+          "is_overnight": false
+        }, 
+        {
+          "start": "1000", 
+          "end": "2300", 
+          "day": 1, 
+          "is_overnight": false
+        }, 
+        {
+          "start": "1000", 
+          "end": "2300", 
+          "day": 2, 
+          "is_overnight": false
+        }, 
+        {
+          "start": "1000", 
+          "end": "2300", 
+          "day": 3, 
+          "is_overnight": false
+        }, 
+        {
+          "start": "1000", 
+          "end": "0000", 
+          "day": 4, 
+          "is_overnight": false
+        }, 
+        {
+          "start": "1000", 
+          "end": "0000", 
+          "day": 5, 
+          "is_overnight": false
+        }, 
+        {
+          "start": "1000", 
+          "end": "2300", 
+          "day": 6, 
+          "is_overnight": false
+        }
+      ], 
+      "is_open_now": true
+    }
+  ], 
+  "photos": [
+    "https://s3-media4.fl.yelpcdn.com/bphoto/howYvOKNPXU9A5KUahEXLA/o.jpg", 
+    "https://s3-media3.fl.yelpcdn.com/bphoto/I-CX8nioj3_ybAAYmhZcYg/o.jpg", 
+    "https://s3-media2.fl.yelpcdn.com/bphoto/uaSNfzJUiFDzMeSCwTcs-A/o.jpg"
+  ], 
+  "image_url": "https://s3-media1.fl.yelpcdn.com/bphoto/howYvOKNPXU9A5KUahEXLA/o.jpg", 
+  "location": {
+    "city": "San Francisco", 
+    "country": "US", 
+    "address2": "", 
+    "address3": "", 
+    "state": "CA", 
+    "address1": "123 Second St", 
+    "zip_code": "94105"
+  }, 
+  "id": "north-india-restaurant-san-francisco", 
+  "categories": [
+    {
+      "alias": "indpak", 
+      "title": "Indian"
+    }
+  ]
+}
+{
+  "rating": 5.0, 
+  "review_count": 2, 
+  "name": "Holoholokai Beach Park", 
+  "photos": [
+    "https://s3-media2.fl.yelpcdn.com/bphoto/EVnS_7_BGXGUOEgICcgflA/o.jpg", 
+    "https://s3-media2.fl.yelpcdn.com/bphoto/oDHYGEDpZtq4vHZZ1pjliQ/o.jpg", 
+    "https://s3-media3.fl.yelpcdn.com/bphoto/i9m1EW87EVTpV53OjhHLmQ/o.jpg"
+  ], 
+  "url": "https://www.yelp.com/biz/holoholokai-beach-park-waimea?adjust_creative=IsIDClmA95d_bteaxrfQSg&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_lookup&utm_source=IsIDClmA95d_bteaxrfQSg", 
+  "coordinates": {
+    "latitude": 19.9511290439855, 
+    "longitude": -155.855140124072
+  }, 
+  "hours": [
+    {
+      "hours_type": "REGULAR", 
+      "open": [], 
+      "is_open_now": false
+    }
+  ], 
+  "phone": "", 
+  "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/EVnS_7_BGXGUOEgICcgflA/o.jpg", 
+  "location": {
+    "city": "Waimea", 
+    "country": "US", 
+    "address2": "", 
+    "address3": "", 
+    "state": "HI", 
+    "address1": "72-88 N Kaniku Dr", 
+    "zip_code": "96743"
+  }, 
+  "id": "holoholokai-beach-park-waimea", 
+  "categories": [
+    {
+      "alias": "beaches", 
+      "title": "Beaches"
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pyrebase
 pytest
 pygeohash
 requests
+sanction
 wikipedia
 yelp

--- a/samples/yelp-test.py
+++ b/samples/yelp-test.py
@@ -1,21 +1,26 @@
 import json
 import pprint
 
-from app.clients import yelpClient, factualClient
+from app.clients import yelpClient, yelp3Client
 from app.representation import venueRecord
 
-categories="beaches"
+# categories="beaches"
 
-def getLocality(lat, lon, **kwargs):
-    return yelpClient.search_by_coordinates(lat, lon, **kwargs)
+# def getLocality(lat, lon, **kwargs):
+#     return yelpClient.search_by_coordinates(lat, lon, **kwargs)
 
-locality = getLocality(19.915403, -155.887403, 
-  radius_filter=25000, 
-  sort=1, 
-  limit=20, 
-  offset=0, 
-  category_filter=categories
-)
+# locality = getLocality(19.915403, -155.887403, 
+#   radius_filter=25000, 
+#   sort=1, 
+#   limit=20, 
+#   offset=0, 
+#   category_filter=categories
+# )
 
-businesses = locality.businesses
-print(json.dumps([venueRecord(b) for b in businesses], indent=2))
+# businesses = locality.businesses
+# print(json.dumps([venueRecord(b) for b in businesses], indent=2))
+
+#yelpID = "north-india-restaurant-san-francisco"
+yelpID = "holoholokai-beach-park-waimea"
+yelp3Biz = yelp3Client.request("/businesses/%s" % yelpID)
+print(json.dumps(yelp3Biz, indent=2))


### PR DESCRIPTION
This pull request:
- changes the version of the Yelp API – so no longer uses the Yelp SDK for looking up businesses. This was to allow images and opening hours to be found.
- cleans up the schema/`representation.py` to include images from both wikipedia and yelp.
