### PR TITLE
Cache Factual Crosswalk lookups.

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,10 @@
+
+# Change these names to change what the tables in firebase are called.
+# _tablePrefix = "user_name"
+_tablePrefix = ""
+_venues = "venues"
+_events = "events"
+
+# Don't edit these directly.
+venuesTable = _tablePrefix + _venues
+eventsTable = _tablePrefix + _events

--- a/app/crosswalk.py
+++ b/app/crosswalk.py
@@ -1,6 +1,6 @@
 from app.clients   import factualClient
-from app.constants import debug
 from app.util      import log
+from factual       import APIException
 
 CROSSWALK_CACHE_VERSION = 1
 
@@ -29,9 +29,8 @@ def getVenueIdentifiers(yelpID):
       del idObj["factual_id"]
       del idObj["namespace"]
       mapping[namespace] = idObj
-  except Exception, err:
-    if debug:
-      log.exception("Factual problem " + yelpID)
-    else:
-      log.error("Factual problem with " + yelpID + "; using Yelp only")
+  except APIException:
+    log.error("Factual API failed again")
+  except Exception:
+    log.exception("Factual problem " + yelpID)
   return mapping

--- a/app/crosswalk.py
+++ b/app/crosswalk.py
@@ -5,33 +5,33 @@ from factual       import APIException
 CROSSWALK_CACHE_VERSION = 1
 
 def getVenueIdentifiers(yelpID):
-  yelpURL = "https://yelp.com/biz/%s" % yelpID
-  mapping = {
-    "id": yelpID,
-    "version": CROSSWALK_CACHE_VERSION,
-    "yelp": {
-      "url": yelpURL
+    yelpURL = "https://yelp.com/biz/%s" % yelpID
+    mapping = {
+      "id": yelpID,
+      "version": CROSSWALK_CACHE_VERSION,
+      "yelp": {
+        "url": yelpURL
+      }
     }
-  }
-  try:
-    obj = factualClient.crosswalk().filters({"url": yelpURL}).data()
+    try:
+        obj = factualClient.crosswalk().filters({"url": yelpURL}).data()
 
-    if len(obj) == 0:
-      return mapping
+        if len(obj) == 0:
+            return mapping
 
-    factualID = obj[0]["factual_id"]
-    mapping["factualID"] = factualID
+        factualID = obj[0]["factual_id"]
+        mapping["factualID"] = factualID
 
-    idList = factualClient.crosswalk().filters({"factual_id": factualID}).data()
+        idList = factualClient.crosswalk().filters({"factual_id": factualID}).data()
 
-    for idObj in idList:
-      namespace = idObj["namespace"]
-      del idObj["factual_id"]
-      del idObj["namespace"]
-      mapping[namespace] = idObj
-    return mapping, True
-  except APIException:
-    log.error("Factual API failed again")
-  except Exception:
-    log.exception("Factual problem " + yelpID)
-  return mapping, False
+        for idObj in idList:
+            namespace = idObj["namespace"]
+            del idObj["factual_id"]
+            del idObj["namespace"]
+            mapping[namespace] = idObj
+        return mapping, True
+    except APIException:
+        log.error("Factual API failed again")
+    except Exception:
+        log.exception("Factual problem " + yelpID)
+    return mapping, False

--- a/app/crosswalk.py
+++ b/app/crosswalk.py
@@ -1,0 +1,37 @@
+from app.clients   import factualClient
+from app.constants import debug
+from app.util      import log
+
+CROSSWALK_CACHE_VERSION = 1
+
+def getVenueIdentifiers(yelpID):
+  yelpURL = "https://yelp.com/biz/%s" % yelpID
+  mapping = {
+    "id": yelpID,
+    "version": CROSSWALK_CACHE_VERSION,
+    "yelp": {
+      "url": yelpURL
+    }
+  }
+  try:
+    obj = factualClient.crosswalk().filters({"url": yelpURL}).data()
+
+    if len(obj) == 0:
+      return mapping
+
+    factualID = obj[0]["factual_id"]
+    mapping["factualID"] = factualID
+
+    idList = factualClient.crosswalk().filters({"factual_id": factualID}).data()
+
+    for idObj in idList:
+      namespace = idObj["namespace"]
+      del idObj["factual_id"]
+      del idObj["namespace"]
+      mapping[namespace] = idObj
+  except Exception, err:
+    if debug:
+      log.exception("Factual problem " + yelpID)
+    else:
+      log.error("Factual problem with " + yelpID + "; using Yelp only")
+  return mapping

--- a/app/crosswalk.py
+++ b/app/crosswalk.py
@@ -29,8 +29,9 @@ def getVenueIdentifiers(yelpID):
       del idObj["factual_id"]
       del idObj["namespace"]
       mapping[namespace] = idObj
+    return mapping, True
   except APIException:
     log.error("Factual API failed again")
   except Exception:
     log.exception("Factual problem " + yelpID)
-  return mapping
+  return mapping, False

--- a/app/providers/wp.py
+++ b/app/providers/wp.py
@@ -3,5 +3,5 @@ import wikipedia
 from app.util import slug
 
 def resolve(idObj):
-  pageID = slug(idObj["url"])
-  return wikipedia.page(pageID, preload=True)
+    pageID = slug(idObj["url"])
+    return wikipedia.page(pageID, preload=True)

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -1,3 +1,4 @@
+import json
 from multiprocessing.dummy import Pool as ThreadPool 
 
 import pyrebase
@@ -12,33 +13,49 @@ from app.util import log
 firebase = pyrebase.initialize_app(FIREBASE_CONFIG)
 db = firebase.database()
 
-def writeRecord(biz, **details):
+def writeVenueRecord(biz, details, idObj = None):
     key   = representation.createKey(biz)
     venue = representation.venueRecord(biz, **details)
     geo   = representation.geoRecord(biz)
 
-    db.child(venuesTable).update(
-      {
-        "details/" + key: venue,
-        "locations/" + key: geo 
-      }
-    )
+    record = {
+      "details/" + key: venue,
+      "locations/" + key: geo 
+    }
+
+    if idObj is not None:
+        log.info("caching identifiers for " + key)
+        record["identifiers/" + key] = idObj
+
+    db.child(venuesTable).update(record)
 
     return { key: geo }
+
+def readVenueIdentifiers(key):
+    return db.child(venuesTable).child("identifiers/" + key).get().val()
 
 def researchVenue(biz):
     yelpID = biz.id
     try:
+        venueIdentifiers = readVenueIdentifiers(yelpID)
         # This gets the identifiers from Factual. It's two HTTP requests 
         # per venue. 
-        venueIdentifiers = crosswalk.getVenueIdentifiers(yelpID)
+        crosswalkNeeded = venueIdentifiers is None
+        if crosswalkNeeded:
+            venueIdentifiers, crosswalkAvailable = crosswalk.getVenueIdentifiers(yelpID)
+
         # This then uses the identifiers to look up (resolve) details.
         # We'll fan out these as much as possible.
         venueDetails = search._getVenueDetails(venueIdentifiers)
         
         # Once we've got the details, we should stash it in 
         # Firebase.
-        writeRecord(biz, **venueDetails)
+        shouldCacheCrosswalk = (crosswalkNeeded and crosswalkAvailable)
+        if shouldCacheCrosswalk:
+            writeVenueRecord(biz, venueDetails, venueIdentifiers)
+        else:
+            writeVenueRecord(biz, venueDetails)
+
         return yelpID
     except KeyboardInterrupt:
         return False

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -4,6 +4,7 @@ import pyrebase
 
 from config import FIREBASE_CONFIG
 from app.constants import venuesTable
+import app.crosswalk as crosswalk
 import app.representation as representation
 import app.search as search
 from app.util import log
@@ -30,7 +31,7 @@ def researchVenue(biz):
     try:
         # This gets the identifiers from Factual. It's two HTTP requests 
         # per venue. 
-        venueIdentifiers = search._getVenueCrosswalk(yelpID)
+        venueIdentifiers = crosswalk.getVenueIdentifiers(yelpID)
         # This then uses the identifiers to look up (resolve) details.
         # We'll fan out these as much as possible.
         venueDetails = search._getVenueDetails(venueIdentifiers)

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -3,11 +3,10 @@ from multiprocessing.dummy import Pool as ThreadPool
 import pyrebase
 
 from config import FIREBASE_CONFIG
+from app.constants import venuesTable
 import app.representation as representation
 import app.search as search
 from app.util import log
-
-VENUES_KEY = "venues"
 
 firebase = pyrebase.initialize_app(FIREBASE_CONFIG)
 db = firebase.database()
@@ -17,7 +16,7 @@ def writeRecord(biz, **details):
     venue = representation.venueRecord(biz, **details)
     geo   = representation.geoRecord(biz)
 
-    db.child(VENUES_KEY).update(
+    db.child(venuesTable).update(
       {
         "details/" + key: venue,
         "locations/" + key: geo 

--- a/app/search.py
+++ b/app/search.py
@@ -37,35 +37,6 @@ def _guessYelpId(placeName, lat, lon):
     else:
         return None
 
-def _getVenueCrosswalk(yelpID):
-    yelpURL = "https://yelp.com/biz/%s" % yelpID
-    mapping = {
-      "id": yelpID,
-      "version": CROSSWALK_CACHE_VERSION,
-      "yelp": {
-        "url": yelpURL
-      }
-    }
-    try:
-      obj = factualClient.crosswalk().filters({"url": yelpURL}).data()
-
-      if len(obj) == 0:
-          return mapping
-
-      factualID = obj[0]["factual_id"]
-      mapping["factualID"] = factualID
-
-      idList = factualClient.crosswalk().filters({"factual_id": factualID}).data()
-
-      for idObj in idList:
-          namespace = idObj["namespace"]
-          del idObj["factual_id"]
-          del idObj["namespace"]
-          mapping[namespace] = idObj
-    except Exception as err:
-        log.error("Factual problem with " + yelpID + "; using Yelp only")
-    return mapping
-
 def _getVenueDetailsFromProvider(arg):
     (namespace, idObj) = arg
     venueDetails = {}

--- a/app/util.py
+++ b/app/util.py
@@ -3,7 +3,9 @@ import re
 
 logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger('prox')
+log.level = logging.DEBUG
 
+debugging = log.isEnabledFor(logging.DEBUG)
 
 _slugPattern = re.compile("/([^/\?]*)(\?.*)?$")
 

--- a/app/yelp3.py
+++ b/app/yelp3.py
@@ -13,20 +13,15 @@ class Yelp3Client:
         if self.client.access_token is not None:
             from datetime import datetime, timedelta
             from time import mktime
-            now = mktime(datetime.utcnow().timetuple())
+            now = mktime(datetime.utcnow().timetuple()) + 60
             if now <= self.client.token_expires:
                 return self.client.access_token  
-
         self.client.request_token(grant_type="client_credentials")
         return self.client.access_token
 
     def request(self, endpoint):
         access_token = self.refreshAccessToken()
         return self.client.request(endpoint, 
-            method="GET", 
-            headers={'Authorization': 'Bearer {0}'.format(access_token)}
+          method="GET", 
+          headers={'Authorization': 'Bearer {0}'.format(access_token)}
         )
-
-
-
-

--- a/keys.local.template.json
+++ b/keys.local.template.json
@@ -11,5 +11,5 @@
     "token_secret"    : "YOUR_TOKEN_SECRET"
   },
 
-  "googleapikey": "GOOGLE_API_KEY"
+  "googleapi_key": "GOOGLE_API_KEY"
 }


### PR DESCRIPTION
This pull request uses the firebase database to cache crosswalk lookups.

With this, we can reduce the number of lookups a day. On cache miss, factual is used as usual 
and the results are stored in firebase. 

On cache miss, and a failure of the factual API, then the server can continue with just the yelp IDs.

This does not cache the results of the venue look up, so any data previously stored will be overwritten, even if less data is available.
