### PR TITLE
Cache API calls in Firebase

### DIFF
--- a/app/providers/wp.py
+++ b/app/providers/wp.py
@@ -4,4 +4,9 @@ from app.util import slug
 
 def resolve(idObj):
     pageID = slug(idObj["url"])
-    return wikipedia.page(pageID, preload=True)
+    page = wikipedia.page(pageID, preload=True)
+    return {
+      "url": page.url,
+      "summary": page.summary,
+      "images": page.images,
+    }

--- a/app/representation.py
+++ b/app/representation.py
@@ -35,11 +35,11 @@ def venueRecord(biz, **details):
     if "wikipedia" in details:
       info = details["wikipedia"]
       providers["wikipedia"] = {
-        "url"        : info.url,
-        "description": info.summary
+        "url"        : info["url"],
+        "description": info["summary"]
       }
-      h["description"] = _descriptionRecord("wikipedia", info.summary)
-      h["images"]     += _imageRecords("wikipedia", info.images, info.url)
+      h["description"] = _descriptionRecord("wikipedia", info["summary"])
+      h["images"]     += _imageRecords("wikipedia", info["images"], info["url"])
 
     # TripAdvisor
     if "tripadvisor" in details:

--- a/app/representation.py
+++ b/app/representation.py
@@ -27,7 +27,7 @@ def venueRecord(biz, **details):
       }
       h["description"] = _descriptionRecord("yelp", biz.snippet_text)
       h["categories"].update([ (c["title"], _categoryRecord(c["alias"], c["title"])) for c in info["categories"] if "title" in c])
-      h["images"]     += _imageRecords("yelp", info["photos"], biz.url)
+      h["images"]     += _imageRecords("yelp", info.get("photos", []), biz.url)
       h["hours"]       = _yelpHoursRecord(info["hours"])
 
 
@@ -134,7 +134,7 @@ def _yelpHoursRecord(hours):
     for day in days:
         record[day] = []
     for section in hours:
-        for dayTime in section["open"]:
+        for dayTime in section.get("open", []):
             day = days[dayTime["day"]]
             record[day] += [
               _yelpTimeFormat(dayTime["start"]),

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -18,22 +18,25 @@ db = firebase.database()
 
 def writeVenueRecord(biz, details, idObj = None):
     key   = representation.createKey(biz)
-    venue = representation.venueRecord(biz, **details)
-    geo   = representation.geoRecord(biz)
+    try:
+        venue = representation.venueRecord(biz, **details)
+        geo   = representation.geoRecord(biz)
+        record = {
+          "details/" + key: venue,
+          "locations/" + key: geo 
+        }
+    except Exception as err:
+        log.exception("Exception preparing to write to firebase for key " + key)
+        record = {}
 
-    record = {
-      "details/" + key: venue,
-      "locations/" + key: geo 
-    }
-
+    record["cache/" + key] = details
     if idObj is not None:
-        cache = details
-        cache["identifiers"] = idObj
-        record["cache/" + key] = cache
+        # we're now going to cache the details, as well as the crosswalk 
+        # identifiers that we used to look them up.
+        details["identifiers"] = idObj
 
     db.child(venuesTable).update(record)
 
-    return { key: geo }
 
 def readCachedVenueDetails(key):
     cache = db.child(venuesTable).child("cache/" + key).get().val()
@@ -45,24 +48,23 @@ def readCachedVenueIdentifiers(cache):
     return None
 
 def researchVenue(biz):
-    yelpID = biz.id
     try:
+        yelpID = representation.createKey(biz)
         cache = readCachedVenueDetails(yelpID)
         venueIdentifiers = readCachedVenueIdentifiers(cache)
         # This gets the identifiers from Factual. It's two HTTP requests 
         # per venue. 
-        crosswalkNeeded = venueIdentifiers is None
-        if crosswalkNeeded:
+        crosswalkedFoundInCached = venueIdentifiers is None
+        if crosswalkedFoundInCached:
             venueIdentifiers, crosswalkAvailable = crosswalk.getVenueIdentifiers(yelpID)
 
         # This then uses the identifiers to look up (resolve) details.
         # We'll fan out these as much as possible.
         venueDetails = search._getVenueDetails(venueIdentifiers, cache)
     
-        
         # Once we've got the details, we should stash it in 
         # Firebase.
-        shouldCacheCrosswalk = (crosswalkNeeded and crosswalkAvailable)
+        shouldCacheCrosswalk = (not crosswalkedFoundInCached) or crosswalkAvailable
         if shouldCacheCrosswalk:
             writeVenueRecord(biz, venueDetails, venueIdentifiers)
         else:

--- a/app/search.py
+++ b/app/search.py
@@ -39,12 +39,17 @@ def _guessYelpId(placeName, lat, lon):
     else:
         return None
 
-def _getVenueDetailsFromProvider(arg):
-    (namespace, idObj) = arg
+def _getVenueDetailsFromProvider(args):
+     return getVenueDetailsFromProvider(*args)
+
+def getVenueDetailsFromProvider(namespace, idObj, cached):
     venueDetails = {}
     if namespace not in resolvers:
         return venueDetails
 
+    if cached is not None:
+        # This should probably check when the cache happened.
+        return cached
     resolve = resolvers[namespace]
     try:
       info = resolve(idObj)
@@ -54,9 +59,11 @@ def _getVenueDetailsFromProvider(arg):
         log.exception("Exeption hitting " + namespace)
     return venueDetails
 
-def _getVenueDetails(venueIdentifiers):
+def _getVenueDetails(venueIdentifiers, cachedDetails = None):
+    if cachedDetails is None:
+        cachedDetails = {}
     from multiprocessing.dummy import Pool as ThreadPool
-    args = [(ns, idObj) for ns, idObj in venueIdentifiers.items() if ns in resolvers]
+    args = [(ns, idObj, cachedDetails.get(ns, None)) for ns, idObj in venueIdentifiers.items() if ns in resolvers]
     
     pool = ThreadPool(10)
     

--- a/app/search.py
+++ b/app/search.py
@@ -48,8 +48,9 @@ def getVenueDetailsFromProvider(namespace, idObj, cached):
         return venueDetails
 
     if cached is not None:
-        # This should probably check when the cache happened.
-        return cached
+        venueDetails[namespace] = cached
+        return venueDetails
+        
     resolve = resolvers[namespace]
     try:
       info = resolve(idObj)


### PR DESCRIPTION
All API calls are cached in Firebase.

Currently, no attempt is made to invalidate the cached data; however, some attempt is made to restore incomplete data if an error occurred last time it was fetched.

The following example would prove illustrative:
1. a new venue is needed to be researched.
2. Crosswalk fails because the API limit has been reached.
3. We fetch data just from Yelp.

The next time the venue is crawled:
1. The same venue is needed to be researched.
2. Crosswalk succeeds, giving IDs for TripAdvisor, and Wikipedia.
3. We don't need to fetch from Yelp, because the data is cached.
4. We fetch from Wikipedia
5. TripAdvisor fails.
6. Crosswalk IDs, Wikipedia and Yelp data are stored in cache.

The next time the venue is crawled,
1. Crosswalk IDs, Wikipedia and Yelp data are restored from cache.
2. Only TripAdvisor data is missing, so we only hit TripAdvisor.
3. Crosswalk IDs, Wikipedia, TripAdvisor and Yelp data are stored in cache.

This bug corresponds to https://github.com/mozilla-mobile/prox-server/issues/23.
