### PR TITLE
Put RQ between Flask and request_handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@ Testing is done via [pytest](pytest.org):
     pytest
 
 All tests should pass before landing on `master`.
+
+## Running
+
+The project is a `flask` server which puts jobs on a `rq` task queue.
+
+Thus, the app is run in three parts:
+
+Run redis:
+
+    redis-server
+
+Then run the flask web app:
+
+    python app.py
+
+Then run the workers which will consume the tasks coming from the web server.
+
+    rq worker -c rq_settings

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, abort
 
-from app.request_handler import searchLocation
+from app.queue.enqueue import searchLocation
 
 
 app = Flask(__name__)
@@ -13,7 +13,8 @@ def index():
 def placeUser(latitude, longitude):
     try:
         latitude, longitude = float(latitude), float(longitude)
-        searchLocation(latitude, longitude)
+        jobCount = searchLocation(latitude, longitude)
+        return "OK %.8f,%.8f / %d" % (latitude, longitude, jobCount)
     except ValueError:
         abort(404)
     except KeyboardInterrupt:
@@ -23,7 +24,7 @@ def placeUser(latitude, longitude):
         from app.util import log
         log.exception("Unknown exception")
         abort(500)
-    return "OK - %.4f, %.4f" % (latitude, longitude)
+    
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/app/queue/enqueue.py
+++ b/app/queue/enqueue.py
@@ -1,0 +1,23 @@
+from redis import Redis
+from rq import Queue
+
+from app.util import debugging
+from app.request_handler import searchLocationWithErrorRecovery
+
+# http://python-rq.org/docs/
+if debugging:
+    async = False
+    ttl = 60
+else:
+    async = True
+    # The job will expire after 10 minutes of waiting.
+    ttl = 1200
+
+# Tell RQ what Redis connection to use
+redis_conn = Redis()
+
+q = Queue("api_search", connection=redis_conn, async=async)
+
+def searchLocation(lat, lng):
+    job = q.enqueue_call(func=searchLocationWithErrorRecovery, args=(lat, lng), ttl=ttl)
+    return q.count

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -63,9 +63,9 @@ def findSearchRecord(center, radius=1000):
             # double check that we're within distance
             circleDistance = geo.distance(center, record["l"]) * 1000
             # 1000 m in 1 km (geo.distance is in km, searchCacheRadius is in m)
-            log.info("Circle distance is " + str(circleDistance))
             if circleDistance < searchCacheRadius:
                 return record
+            log.info("Circle distance is " + str(circleDistance))
 
 
 def readCachedVenueDetails(key):
@@ -123,7 +123,7 @@ def searchLocationWithErrorRecovery(lat, lon):
 def searchLocation(lat, lon):
     searchRecord = findSearchRecord((lat, lon), searchCacheRadius)
     if searchRecord is not None:
-        log.info("searchRecord: %s" % searchRecord)
+        log.debug("searchRecord: %s" % searchRecord)
         return
     else:
         writeSearchRecord(lat, lon)

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -110,6 +110,16 @@ def researchVenue(biz):
         log.exception("Error researching venue")
         return False
 
+def searchLocationWithErrorRecovery(lat, lon):
+    try:
+        searchLocation(lat, lon)
+    except KeyboardInterrupt:
+        log.info("GOODBYE")
+        sys.exit(1)
+    except Exception, err:
+        from app.util import log
+        log.exception("Unknown exception")
+
 def searchLocation(lat, lon):
     searchRecord = findSearchRecord((lat, lon), searchCacheRadius)
     if searchRecord is not None:

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -110,9 +110,9 @@ def researchVenue(biz):
         log.exception("Error researching venue")
         return False
 
-def searchLocationWithErrorRecovery(lat, lon):
+def searchLocationWithErrorRecovery(lat, lng):
     try:
-        searchLocation(lat, lon)
+        searchLocation(lat, lng)
     except KeyboardInterrupt:
         log.info("GOODBYE")
         sys.exit(1)
@@ -120,15 +120,15 @@ def searchLocationWithErrorRecovery(lat, lon):
         from app.util import log
         log.exception("Unknown exception")
 
-def searchLocation(lat, lon):
-    searchRecord = findSearchRecord((lat, lon), searchCacheRadius)
+def searchLocation(lat, lng):
+    searchRecord = findSearchRecord((lat, lng), searchCacheRadius)
     if searchRecord is not None:
         log.debug("searchRecord: %s" % searchRecord)
         return
     else:
-        writeSearchRecord(lat, lon)
+        writeSearchRecord(lat, lng)
 
-    locality = search._getVenuesFromIndex(lat, lon)
+    locality = search._getVenuesFromIndex(lat, lng)
 
     yelpVenues = locality.businesses
 

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -116,7 +116,7 @@ def searchLocationWithErrorRecovery(lat, lon):
     except KeyboardInterrupt:
         log.info("GOODBYE")
         sys.exit(1)
-    except Exception, err:
+    except Exception:
         from app.util import log
         log.exception("Unknown exception")
 

--- a/app/util.py
+++ b/app/util.py
@@ -3,7 +3,7 @@ import re
 
 logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger('prox')
-log.level = logging.DEBUG
+log.level = logging.INFO
 
 debugging = log.isEnabledFor(logging.DEBUG)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ foursquare
 pyrebase
 pytest
 pygeohash
+redis
+rq
 sanction
 wikipedia
 yelp

--- a/rq_settings.py
+++ b/rq_settings.py
@@ -1,0 +1,10 @@
+# REDIS_URL = 'redis://localhost:6379/1'
+
+# You can also specify the Redis DB to use
+# REDIS_HOST = 'redis.example.com'
+# REDIS_PORT = 6380
+# REDIS_DB = 3
+# REDIS_PASSWORD = 'very secret'
+
+# Queues to listen on
+QUEUES = ['api_search']


### PR DESCRIPTION
This pull request puts a redis driven job queue between the flask endpoint and the `searchLocation` function.

It adds new deployment instructions.

It uses a default Redis configuration. This may need to change when moving to production.