### PR TITLE
Improve yelp search terms.

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -12,7 +12,7 @@ def _findTablePrefix():
             # production
             return "production/" 
     # development
-    return username + "/"
+    return username + "-test/"
 
 _tablePrefix = _findTablePrefix()
 _venues = "venues"

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -184,18 +184,21 @@ def _guessYelpId(placeName, lat, lon):
         return cachedId
 
     opts = {
-      # 'term': placeName,
+      # 'term': placeName, # Yelp does a bad job with term searching
       'limit': 20,
-      'radius_filter': 1000,
-      #'radius_filter': 100,
+      #'radius_filter': 1000,
       #'sort_by': 'distance',
       'sort': 1,
     }
     r = yelpClient.search_by_coordinates(lat, lon, **opts)
     if len(r.businesses) > 0:
         location = (lat, lon)
-        biz = min(r.businesses, key=lambda b: 
-            geo.distance(location, 
+        businessesWithCoords = filter(
+            lambda b:
+                (b.location is not None) and (b.location.coordinate is not None),
+            r.businesses)
+        biz = min(businessesWithCoords, key=lambda b:
+            geo.distance(location,
                          (b.location.coordinate.latitude, b.location.coordinate.longitude))
         )
         log.debug("%s --> %s" % (placeName, biz.name))
@@ -209,7 +212,6 @@ def _guessYelpId(placeName, lat, lon):
     else:
         log.info("Can't find %s" % placeName)
         return None
-
 
 def writeEventRecord(eventObj):
     key   = representation.createEventKey(eventObj)


### PR DESCRIPTION
There were a few locations where Yelp returned a null full biz.location.coordinate, so I wrapped this in a try.

I also found that adding the term back in improves the search results - I think the problem was that the original param was radius not radius_filter, so the search results weren't being limited by radius.