### PR TITLE
Clean up gcal updating

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -37,7 +37,6 @@ searchesTable = _tablePrefix + _searches
 konaLatLng = { "lat": 19.622345, "lng": -155.665041 }
 
 calendarInfo = {
-    "calRefreshSec": 3600,
     "googleCalendarUrl": "https://www.googleapis.com/calendar/v3/calendars/{}/events?key={}",
     "calendarIds": [ "mozilla.com_avh8q3pubnr4uj419aaubpat2g@group.calendar.google.com" ],
     "eventfulUrl": "https://api.eventful.com/json/events/search"

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -3,7 +3,6 @@ import datetime
 from dateutil import parser
 import json
 from multiprocessing.dummy import Pool as ThreadPool 
-import threading
 
 import pyrebase
 
@@ -20,7 +19,7 @@ import app.representation as representation
 import app.search as search
 import app.events as events
 import app.geo as geo
-from app.util import log, scheduler
+from app.util import log
 
 import sys
 reload(sys)  
@@ -257,24 +256,11 @@ def deleteEvent(key):
         "locations/" + key: None
     })
 
-# Fetching events from Google Calendar
-def startGcalThread():
-    scheduler.enter(10, 1, updateFromGcals, ())
-    t = threading.Thread(target=scheduler.run)
-    t.setDaemon(True)
-    t.start()
-
 def updateFromGcals():
-    try:
-        loadCalendarEvents(datetime.timedelta(days=1))
-        scheduler.enter(calendarInfo["calRefreshSec"], 1, updateFromGcals, ())
+    loadCalendarEvents(datetime.timedelta(days=1))
 
-        # Prune old events
-        pruneEvents()
-    except Exception as err:
-        from app.util import log
-        log.exception("Error running scheduled calendar fetch")
-        scheduler.enter(calendarInfo["calRefreshSec"], 1, updateFromGcals, ())
+    # Prune old events
+    pruneEvents()
 
 def loadCalendarEvents(timeDuration):
     for calId in calendarInfo["calendarIds"]:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 from flask import Flask, abort
 
 from app.queue.enqueue import searchLocation
-from app.request_handler import startGcalThread
 
 app = Flask(__name__)
 
@@ -27,5 +26,4 @@ def placeUser(latitude, longitude):
     
 
 if __name__ == '__main__':
-    startGcalThread()
     app.run(debug=True)


### PR DESCRIPTION
This is further cleanup of the updateGcal code, mainly by removing the scheduler and the 10-minute delay in starting the fetch - all no longer needed because the gcal polling is now handled by cronjob.