### PR TITLE
Add event-location caching script for moz locations.

### DIFF
--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -1,6 +1,7 @@
 from app.util import log
 import datetime
 from dateutil import parser
+import hashlib
 import json
 from multiprocessing.dummy import Pool as ThreadPool 
 
@@ -177,8 +178,8 @@ def searchLocation(lat, lng, radius, maxNum):
     log.info("Found %d: %s" % (len(res), json.dumps(res)))
 
 def _guessYelpId(placeName, lat, lon):
-    safePlaceName = placeName.replace(".", "_")
-    cachedId = db.child(eventsTable).child("cache/" + safePlaceName).get().val()
+    safePlaceId = hashlib.md5(placeName).hexdigest()
+    cachedId = db.child(eventsTable).child("cache/" + safePlaceId).get().val()
     if cachedId:
         return cachedId
 
@@ -204,7 +205,7 @@ def _guessYelpId(placeName, lat, lon):
         researchVenue(biz)
 
         # Add bizId to cache
-        record = { "cache/" +  safePlaceName : str(biz.id) }
+        record = { "cache/" +  safePlaceId: str(biz.id) }
         db.child(eventsTable).update(record)
 
         return biz.id
@@ -254,7 +255,7 @@ def pruneEvents():
 def deleteEvent(key):
     db.child(eventsTable).update({
         "details/" + key: None,
-        "cache/" + key: None,
+    #    "cache/" + key: None, # For Kona, do not delete the cache because we hard-code the moz-specific locations
         "locations/" + key: None
     })
 

--- a/scripts/cache-moz-locations.py
+++ b/scripts/cache-moz-locations.py
@@ -1,0 +1,34 @@
+'''
+Our event location-guessing uses Yelp APIs but they don't do a good job. This script caches and stores the locations that we need.
+For Kona, we will not clear out the location or id cache. See 'request_handler.deleteEvent'.
+'''
+
+import hashlib
+import pyrebase
+
+from app.clients import yelpClient
+from app.constants import eventsTable
+from app.request_handler import researchVenue
+from config import FIREBASE_CONFIG
+
+MOZ_LOCATIONS = {"Hilton Waikoloa Village, 69-425 Waikoloa Beach Dr, Waikoloa Village, HI 96738, USA": "hilton-waikoloa-village-waikoloa-2"}
+
+firebase = pyrebase.initialize_app(FIREBASE_CONFIG)
+db = firebase.database()
+
+def clearEventsDir():
+    db.child(eventsTable).remove()
+
+def forceCache(locationDict):
+    for key in locationDict:
+        yelpID = locationDict[key]
+        safePlaceId = hashlib.md5(key).hexdigest()
+
+        # Fetch location and add it to Locations
+        biz = yelpClient.get_business(yelpID)
+        researchVenue(biz.business)
+
+        record = { "cache/" +  safePlaceId: yelpID }
+        db.child(eventsTable).update(record)
+
+forceCache(MOZ_LOCATIONS)


### PR DESCRIPTION
(You'll probably want to merge #78 first, bc it fixes a debug statement I had left in, and also ups the gcal fetch limits so events will actually get fetched.)

This must run on an empty events database - otherwise, events that have already matched to the wrong (for example) Hilton Waikoloa will not be fixed, and writing a script iterate through and correct everything isn't worthwhile.

To verify this, I ran scripts/update-gcals.py to see that instead of pointing to Hilton Waikoloa, a bunch of the places point towards Donna & Toni's Pizza.

Cleared my events db, ran this caching script, and then ran the scripts/update-gcals.py again. Places now point correctly to Hilton Waikoloa.

