### PR TITLE
Ensure rq workers listen on the correct queues.

### DIFF
--- a/scripts/systemd/prox-rq-backend.service
+++ b/scripts/systemd/prox-rq-backend.service
@@ -3,7 +3,7 @@ Description=prox backend
 
 [Service]
 WorkingDirectory=/home/prox/prox-server
-ExecStart=/home/prox/prox-server/env/bin/rq worker rq_settings
+ExecStart=/home/prox/prox-server/env/bin/rq worker -c rq_settings
 Restart=always
 User=prox
 Group=prox


### PR DESCRIPTION
Add -c to use the configuration file called rq_settings, not the queue called rq_settings.