### PR TITLE
Expand crawl to include TripAdvisor

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -19,6 +19,7 @@ _venues = "venues"
 _events = "events"
 _searches = "searches"
 _locations = "locations"
+_proxwalk = "proxwalk"
 _cache = "cache"
 
 # number of seconds after a search in a given area that it should be cached.
@@ -36,6 +37,7 @@ eventsTable = _tablePrefix + _events
 searchesTable = _tablePrefix + _searches
 locationsTable = _tablePrefix + _venues + '/' + _locations
 cacheTable = _tablePrefix + _venues + '/' + _cache
+proxwalkTable = venuesTable + "/" + _proxwalk
 
 statusTable = "api_availability"
 

--- a/app/providers/tripadvisor.py
+++ b/app/providers/tripadvisor.py
@@ -15,11 +15,14 @@ TRIP_ADVISOR_API = "https://api.tripadvisor.com/api/partner/2.0/location/{}"
 params = { "key": tripadvisorkey }
 
 def resolve(idObj):
-    url = idObj["url"]
-    taId = getNumId(url)
-    apiUrl = TRIP_ADVISOR_API.format(taId)
+    apiUrl = TRIP_ADVISOR_API.format(idObj)
     return requests.get(apiUrl, params).json()
 
+# Extract id object from Factual Crosswalk id object
+def getIdFromIdObj(idObj):
+    url = idObj["url"]
+    taId = getNumId(url)
+    return taId
 
 TRIP_ADVISOR_LOC_MAPPER_API = 'http://api.tripadvisor.com/api/partner/2.0/location_mapper/{}'
 

--- a/app/providers/tripadvisor.py
+++ b/app/providers/tripadvisor.py
@@ -14,15 +14,17 @@ def getNumId(idStr):
 TRIP_ADVISOR_API = "https://api.tripadvisor.com/api/partner/2.0/location/{}"
 params = { "key": tripadvisorkey }
 
-def resolve(idObj):
-    apiUrl = TRIP_ADVISOR_API.format(idObj)
+def resolve_with_key(key):
+    apiUrl = TRIP_ADVISOR_API.format(key)
     return requests.get(apiUrl, params).json()
 
-# Extract id object from Factual Crosswalk id object
-def getIdFromIdObj(idObj):
+def resolve(idObj):
+    """
+    Extract id object from Factual Crosswalk id object
+    """
     url = idObj["url"]
     taId = getNumId(url)
-    return taId
+    return resolve_with_key(taId)
 
 TRIP_ADVISOR_LOC_MAPPER_API = 'http://api.tripadvisor.com/api/partner/2.0/location_mapper/{}'
 

--- a/app/representation.py
+++ b/app/representation.py
@@ -69,7 +69,7 @@ def updateRecord(yelpID, **details):
           firstReview = reviews[0]["text"]
 
       providers["tripAdvisor"] = {
-        "rating"          : float(info["rating"]), # This is the aggregate rating
+        "rating"          : float(info["rating"]) if info["rating"] else None, # This is the aggregate rating
         "totalReviewCount": int(info["num_reviews"]),
         "description"     : firstReview, # The rating of this review is not included
         "url"             : info["web_url"]

--- a/app/representation.py
+++ b/app/representation.py
@@ -68,12 +68,15 @@ def updateRecord(yelpID, **details):
       if len(reviews) > 0:
           firstReview = reviews[0]["text"]
 
-      providers["tripAdvisor"] = {
-        "rating"          : float(info["rating"]) if info["rating"] else None, # This is the aggregate rating
-        "totalReviewCount": int(info["num_reviews"]),
-        "description"     : firstReview, # The rating of this review is not included
-        "url"             : info["web_url"]
-      }
+      try:
+          providers["tripAdvisor"] = {
+            "rating"          : float(info["rating"]) if info["rating"] else None, # This is the aggregate rating, and can be empty
+            "totalReviewCount": int(info["num_reviews"]),
+            "description"     : firstReview, # The rating of this review is not included
+            "url"             : info["web_url"]
+          }
+      except KeyError:
+          log.debug("TripAdvisor weird for " + biz.id)
 
     # Foursquare
     if "foursquare" in details:

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -45,26 +45,9 @@ def writeYelpRecords(yelpVenues):
 
     db.child(venuesTable).update(record)
 
-def writeVenueRecord(biz, details, idObj = None):
-    key = representation.createKey(biz)
-    try:
-        venue = representation.venueRecord(biz, **details)
-        geo = representation.geoRecord(biz)
-        record = {
-          "details/" + key: venue,
-          "locations/" + key: geo 
-        }
-    except Exception as err:
-        log.exception("Exception preparing to write to firebase for key " + key)
-        record = {}
-
-    record["cache/" + key] = details
-    if idObj is not None:
-        # we're now going to cache the details, as well as the crosswalk 
-        # identifiers that we used to look them up.
-        details["identifiers"] = idObj
-
-    db.child(venuesTable).update(record)
+def writeVenueRecord(yelpID, details, idObj = None):
+    venue = representation.updateRecord(yelpID, **details)
+    db.child(venuesTable).child("details").child(yelpID).update(venue)
 
 def writeSearchRecord(lat, lng, key=None):
     record = representation._geoRecord(lat, lng)
@@ -109,9 +92,8 @@ def readCachedVenueIdentifiers(cache):
         return cache.get("identifiers", None)
     return None
 
-def researchVenue(biz):
+def researchVenue(yelpID):
     try:
-        yelpID = representation.createKey(biz)
         cache = readCachedVenueDetails(yelpID)
         venueIdentifiers = readCachedVenueIdentifiers(cache)
         # This gets the identifiers from Factual. It's two HTTP requests 
@@ -128,9 +110,9 @@ def researchVenue(biz):
         # Firebase.
         shouldCacheCrosswalk = (not crosswalkedFoundInCached) or crosswalkAvailable
         if shouldCacheCrosswalk:
-            writeVenueRecord(biz, venueDetails, venueIdentifiers)
+            writeVenueRecord(yelpID, venueDetails, venueIdentifiers)
         else:
-            writeVenueRecord(biz, venueDetails)
+            writeVenueRecord(yelpID, venueDetails)
 
         return yelpID
     except KeyboardInterrupt:

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -46,6 +46,14 @@ def writeYelpRecords(yelpVenues):
 
     db.child(venuesTable).update(record)
 
+def writeVenueProviderRecord(yelpID, details, idObj = None):
+    try:
+        venue = representation.updateRecord(yelpID, **details)
+        for provider, data in venue["providers"].items():
+            db.child(venuesTable).child("details").child(yelpID).child("providers").update({provider: data})
+    except Exception as e:
+        log.error("Error writing record: {}\n{}".format(details, e))
+
 def writeVenueRecord(yelpID, details, idObj = None):
     venue = representation.updateRecord(yelpID, **details)
     db.child(venuesTable).child("details").child(yelpID).update(venue)
@@ -94,12 +102,11 @@ def readCachedVenueIdentifiers(cache):
     return None
 
 def researchPlace(keyID, sourcesList, identifiers):
-    # Overall: Iterate through sources and write them to disk
-    # Get source ID
-    # Check or update Proxwalk
-    # Fetch from source using id and write to firebase
     # TODO: Check more than just Proxwalk
     placeSourceIDs = proxwalk.getSourceIDs(keyID, sourcesList, identifiers)
+    venueDetails = search.getVenueDetails(placeSourceIDs)
+    writeVenueProviderRecord(keyID, venueDetails)
+    return [key.encode('utf-8') for key in venueDetails.keys()]
 
 def researchVenue(yelpID):
     try:

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -16,6 +16,7 @@ from app.constants import \
 
 from app.clients import yelpClient
 import app.crosswalk as crosswalk
+import scripts.prox_crosswalk as proxwalk
 import app.representation as representation
 import app.search as search
 import app.events as events
@@ -91,6 +92,14 @@ def readCachedVenueIdentifiers(cache):
     if cache is not None:
         return cache.get("identifiers", None)
     return None
+
+def researchPlace(keyID, sourcesList, identifiers):
+    # Overall: Iterate through sources and write them to disk
+    # Get source ID
+    # Check or update Proxwalk
+    # Fetch from source using id and write to firebase
+    # TODO: Check more than just Proxwalk
+    placeSourceIDs = proxwalk.getSourceIDs(keyID, sourcesList, identifiers)
 
 def researchVenue(yelpID):
     try:

--- a/app/request_handler.py
+++ b/app/request_handler.py
@@ -46,17 +46,18 @@ def writeYelpRecords(yelpVenues):
 
     db.child(venuesTable).update(record)
 
-def writeVenueProviderRecord(yelpID, details, idObj = None):
+def writeVenueProviderRecord(yelpID, details):
     try:
         venue = representation.updateRecord(yelpID, **details)
         for provider, data in venue["providers"].items():
-            db.child(venuesTable).child("details").child(yelpID).child("providers").update({provider: data})
+            db.child(venuesTable, "details", yelpID, "providers").update({provider: data})
     except Exception as e:
         log.error("Error writing record: {}\n{}".format(details, e))
 
 def writeVenueRecord(yelpID, details, idObj = None):
+    # idObj is remnant of live-search client calls.
     venue = representation.updateRecord(yelpID, **details)
-    db.child(venuesTable).child("details").child(yelpID).update(venue)
+    db.child(venuesTable, "details", yelpID).update(venue)
 
 def writeSearchRecord(lat, lng, key=None):
     record = representation._geoRecord(lat, lng)
@@ -101,10 +102,10 @@ def readCachedVenueIdentifiers(cache):
         return cache.get("identifiers", None)
     return None
 
-def researchPlace(keyID, sourcesList, identifiers):
+def researchPlace(keyID, providersList, identifiers):
     # TODO: Check more than just Proxwalk
-    placeSourceIDs = proxwalk.getSourceIDs(keyID, sourcesList, identifiers)
-    venueDetails = search.getVenueDetails(placeSourceIDs)
+    placeProviderIDs = proxwalk.getAndCacheProviderIDs(keyID, providersList, identifiers)
+    venueDetails = search.getVenueDetails(placeProviderIDs)
     writeVenueProviderRecord(keyID, venueDetails)
     return [key.encode('utf-8') for key in venueDetails.keys()]
 

--- a/app/search.py
+++ b/app/search.py
@@ -11,7 +11,7 @@ from app.clients import yelpClient, factualClient, googleapikey
 from app.providers.fs import resolve as resolveFoursquare
 from app.providers.yelp import resolve as resolveYelp
 from app.providers.wp import resolve as resolveWikipedia
-from app.providers.tripadvisor import resolve as resolveTripAdvisor
+from app.providers.tripadvisor import resolve_with_key as resolveTripAdvisor
 from app.providers.factual_places import resolve as resolveFactualPlace
 from app.util import log
 from app.constants import venueSearchRadius
@@ -139,7 +139,7 @@ def getVenueDetailsFromProvider(namespace, idObj, cached):
         
     resolve = resolvers[namespace]
     try:
-        # NB: This is updated to handle ids directly, rather than parsing from an object
+      # TODO: Handle parsing Crosswalk id out of url in addition to Proxwalk provider id
       info = resolve(idObj)
       if info is not None:
           venueDetails[namespace] = info

--- a/app/search.py
+++ b/app/search.py
@@ -139,6 +139,7 @@ def getVenueDetailsFromProvider(namespace, idObj, cached):
         
     resolve = resolvers[namespace]
     try:
+        # NB: This is updated to handle ids directly, rather than parsing from an object
       info = resolve(idObj)
       if info is not None:
           venueDetails[namespace] = info

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pytest
 pytz
 pygeohash
 python-dateutil
+python-Levenshtein
 redis
 rq
 sanction

--- a/scripts/crawl_expand.py
+++ b/scripts/crawl_expand.py
@@ -1,0 +1,49 @@
+"""Crawls existing places in Firebase, expanding their data using multiple
+sources.
+
+This script only searches for places that are already in the database; use
+`crawl_base.py` to populate the initial set of places.
+
+To cache the results in the production database, see readme.
+
+"""
+from app.util import log
+
+import pyrebase
+import app.request_handler as request_handler
+
+from config import FIREBASE_CONFIG
+from app import geo
+from app.constants import venuesTable, locationsTable
+
+firebase = pyrebase.initialize_app(FIREBASE_CONFIG)
+db = firebase.database()
+
+"""
+Expands cached venue details by fetching additional sources
+Config is of the form:
+    { <provider>: <version> }
+where version is the newest version status
+"""
+def expandPlaces(config, center, radius_km):
+    statusCache = db.child(venuesTable).child("status").get()
+
+    # Fetch placeIDs to expand 
+    location_table = db.child(locationsTable).get().val()
+    placeIDs = geo.get_place_ids_in_radius(center, radius_km, location_table)
+
+    for placeID in placeIDs:
+        placeStatus = statusCache.val()[placeID]
+        # Get a list of (src, version) pairs that could be updated 
+        newSources = [(src, config[src]) for src in config if src not in placeStatus or config[src] > placeStatus[src]]
+        if not newSources:
+            continue
+#        researchVenue(keyID, venue.val()["identifiers"], newSources)
+        print("done: %s" % placeID)
+        exit(0)
+
+testConfig = { "yelp": 1,
+               "tripadvisor": 1 }
+
+chicago_center = (41.8338725,-87.688585)
+expandPlaces(testConfig, chicago_center, 30)

--- a/scripts/crawl_expand.py
+++ b/scripts/crawl_expand.py
@@ -35,10 +35,10 @@ def expandPlaces(config, center, radius_km):
     for placeID in placeIDs:
         placeStatus = statusCache.val()[placeID]
         # Get a list of (src, version) pairs that could be updated 
-        newSources = [(src, config[src]) for src in config if src not in placeStatus or config[src] > placeStatus[src]]
+        newSources = [src for src in config if src not in placeStatus or config[src] > placeStatus[src]]
         if not newSources:
             continue
-#        researchVenue(keyID, venue.val()["identifiers"], newSources)
+        request_handler.researchPlace(placeID, newSources, placeStatus["identifiers"])
         print("done: %s" % placeID)
         exit(0)
 

--- a/scripts/crawl_expand.py
+++ b/scripts/crawl_expand.py
@@ -35,8 +35,8 @@ def expandPlaces(config, center, radius_km):
 
     for placeID in placeIDs:
         placeStatus = statusTable.val()[placeID]
-        # Get a list of (src, version) pairs that could be updated 
-        newSources = [src for src in config if src not in placeStatus or config[src] > placeStatus[src]]
+        # Get a list of (src, version) pairs that could be updated, skip searched places
+        newSources = [src for src in config if src not in placeStatus or (config[src] > placeStatus[src] and config[src] != 0)]
         if not newSources:
             log.info("No new sources for {}".format(placeID))
             continue

--- a/scripts/crawl_expand.py
+++ b/scripts/crawl_expand.py
@@ -26,21 +26,23 @@ Config is of the form:
 where version is the newest version status
 """
 def expandPlaces(config, center, radius_km):
-    statusCache = db.child(venuesTable).child("status").get()
+    statusTable = db.child(venuesTable).child("status").get()
 
     # Fetch placeIDs to expand 
     location_table = db.child(locationsTable).get().val()
     placeIDs = geo.get_place_ids_in_radius(center, radius_km, location_table)
 
     for placeID in placeIDs:
-        placeStatus = statusCache.val()[placeID]
+        placeStatus = statusTable.val()[placeID]
         # Get a list of (src, version) pairs that could be updated 
         newSources = [src for src in config if src not in placeStatus or config[src] > placeStatus[src]]
         if not newSources:
             continue
-        request_handler.researchPlace(placeID, newSources, placeStatus["identifiers"])
-        print("done: %s" % placeID)
-        exit(0)
+        updatedSources = request_handler.researchPlace(placeID, newSources, placeStatus["identifiers"])
+        # Write updated sources to /status
+        placeStatus = db.child(venuesTable).child("status").child(placeID)
+        for source in newSources:
+            placeStatus.update({source: config[source] if source in updatedSources else 0})
 
 testConfig = { "yelp": 1,
                "tripadvisor": 1 }

--- a/scripts/prox_crosswalk.py
+++ b/scripts/prox_crosswalk.py
@@ -42,8 +42,7 @@ def getSourceIDs(keyID, sourcesList, identifiers):
     foundSources = _getCachedIDsForPlace(keyID, sourcesList)
     toFetch = [source for source in sourcesList if source not in foundSources]
     foundSources.update(fetchAndCacheSources(keyID, toFetch, identifiers))
-    # TODO: fetch from each source, and error if there is a problem
-    # TODO: return list of UPDATED sources?
+    return foundSources
 
 def fetchAndCacheSources(keyID, sourcesList, identifiers):
     newSources = {}
@@ -51,9 +50,9 @@ def fetchAndCacheSources(keyID, sourcesList, identifiers):
     name = identifiers["name"]
     for source in sourcesList:
         if source == "tripadvisor":
-            res = ta.search(coordinates, name)
+            res = ta.search(coordinates, name)["data"]
             if res:
-                taID = res["data"][0]["location_id"]
+                taID = res[0]["location_id"]
                 newSources.update({source: taID})
         # TODO: Add other sources
     _write_crosswalk_to_db(keyID, newSources)


### PR DESCRIPTION
This matches items from Yelp to TripAdvisor, writes to our proxwalk db, and fetches TripAdvisor content and writes it to Firebase.

For timing, I test-ran this for 2km around the Chicago center - the crawl_base script takes 9.9s and finds 335 places, and this takes 4:07min matches 24 of those.

This doesn't add wikipedia, but I'll add that on top of this branch.

To run this, make sure you have an area crawled, and then run scripts/expandPlaces.py.