### PR TITLE
Add crawling for yelp v3 for categories and images

### DIFF
--- a/app/representation.py
+++ b/app/representation.py
@@ -36,8 +36,8 @@ def updateRecord(yelpID, **details):
     providers = {}
 
     # Yelp v3.
-    if "yelp" in details:
-      info = details["yelp"]
+    if "yelp3" in details:
+      info = details["yelp3"]
       categories = None
       if "categories" in info:
         categories = [
@@ -45,7 +45,7 @@ def updateRecord(yelpID, **details):
           for c in info["categories"]
           if "title" in c
         ]
-      providers["yelpv3"] = {
+      providers["yelp3"] = {
         "images"    : _imageRecords(info.get("photos", []), info["url"]),
         "hours"     : _yelpHoursRecord(info.get("hours", None)),
         "categories": categories,

--- a/app/search.py
+++ b/app/search.py
@@ -9,7 +9,7 @@ from math import sqrt
 from app.clients import yelpClient, factualClient, googleapikey
 
 from app.providers.fs import resolve as resolveFoursquare
-from app.providers.yelp import resolve as resolveYelp
+from app.providers.yelp import resolve_with_key as resolveYelp
 from app.providers.wp import resolve as resolveWikipedia
 from app.providers.tripadvisor import resolve_with_key as resolveTripAdvisor
 from app.providers.factual_places import resolve as resolveFactualPlace
@@ -54,7 +54,7 @@ DEFAULT_COUNTRY_GOOGLEAPI = 'country:US'
 
 resolvers = {
     "foursquare": resolveFoursquare,
-    "yelp": resolveYelp,
+    "yelp3": resolveYelp,
     "wikipedia": resolveWikipedia,
     "tripadvisor": resolveTripAdvisor,
     "factual": resolveFactualPlace,

--- a/scripts/prox_crosswalk.py
+++ b/scripts/prox_crosswalk.py
@@ -59,9 +59,11 @@ def fetchAndCacheProviders(keyID, providersList, identifiers):
 
 def _getCachedIDsForPlace(keyID, providersList):
     ret = {}
+    if "yelp3" in sourcesList:
+        ret["yelp3"] = keyID
     cached = _get_proxwalk_db().child(keyID).get().val()
     if not cached:
-        return {}
+        return ret
     for s in cached.keys():
         if s in providersList:
             ret.update({s: cached[s]})


### PR DESCRIPTION
This pull request makes one API change to the Firebase data, where the yelpv3 data is saved under "providers/yelp3" rather than "providers/yelpv3".