### PR TITLE
Add scripts for measuring crawl status.

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,4 +1,5 @@
 import getpass
+from enum import Enum
 
 # Change these names to change what the tables in firebase are called.
 def _findTablePrefix():
@@ -59,4 +60,6 @@ GPS_LOCATIONS = {
     "METROPOLIS_COFFEE" : (41.994339, -87.657278)
 }
 
-
+class Status(Enum):
+    NOT_FOUND = 0
+    FETCH_FAILED = -1

--- a/scripts/crawl_expand.py
+++ b/scripts/crawl_expand.py
@@ -14,15 +14,12 @@ import app.request_handler as request_handler
 
 from config import FIREBASE_CONFIG
 from app import geo
-from app.constants import venuesTable, locationsTable, GPS_LOCATIONS
+from app.constants import venuesTable, locationsTable, GPS_LOCATIONS, Status
 from multiprocessing.dummy import Pool as ThreadPool
 from scripts import prox_crosswalk as proxwalk
 
 
 firebase = pyrebase.initialize_app(FIREBASE_CONFIG)
-
-NOT_FOUND = 0
-FETCH_FAILED = -1
 
 def expandPlaces(config, center, radius_km):
     """
@@ -43,7 +40,7 @@ def expandPlaces(config, center, radius_km):
         placeStatus = statusTable[placeID]
         # Get a list of (src, version) pairs that could be updated, skip searched places
         # TODO: Gracefully handle if TripAdvisor-mapper runs out of API calls (25k)
-        newProviders = [src for src in config if src not in placeStatus or (config[src] > placeStatus[src] and placeStatus[src] != NOT_FOUND)]
+        newProviders = [src for src in config if src not in placeStatus or (config[src] > placeStatus[src] and placeStatus[src] != Status.NOT_FOUND.value)]
         if not newProviders:
 #            log.info("No new sources for {}".format(placeID))
            return
@@ -79,10 +76,10 @@ def makeNewStatusTable(config, updatedProviders, placeProviderIDs, newProviders)
             val = config[source]
         elif source in placeProviderIDs:
             # Couldn't fetch provider details
-            val = FETCH_FAILED
+            val = Status.FETCH_FAILED.value
         elif source in newProviders:
             # Unable to get provider id
-            val = NOT_FOUND
+            val = Status.NOT_FOUND.value
         else:
             continue
         newStatus[source] = val

--- a/scripts/places_missing_provider_data.py
+++ b/scripts/places_missing_provider_data.py
@@ -83,6 +83,19 @@ def calculate_crawled_provider_stats(center, radius_km):
                       "no_match": {},
                       "error": {} }
 
+    proxwalkTable = _firebase.database().child(venuesTable, "proxwalk").get().val()
+    prox_dict = {}
+    prox_dict["total"] = len(proxwalkTable)
+
+    for placeID in proxwalkTable:
+        children = proxwalkTable[placeID]
+        for child in children:
+            if child not in prox_dict:
+                prox_dict[child] = 0
+            prox_dict[child] += 1
+
+    provider_dict["proxwalk"] = prox_dict
+
     for placeID in placeIDs:
         placeStatus = statusTable[placeID]
         for provider in placeStatus:


### PR DESCRIPTION
This adds some stats for providers regarding places so that we can get a better idea of what places have been successfully fetched, which don't have data for extra providers, and which are currently in error states (e.g. due to API limits, intermittent API failures/timeouts, Firebase write problems, etc).

As the morning of 2/17, the stats look like:
28267 total places found
{'error': {'tripadvisor': 5277, 'yelp3': 369},
 'match': {'tripadvisor': 1533, 'yelp': 28267, 'yelp3': 22896},
 'no_match': {'tripadvisor': 16509, 'yelp3': 4}}

and I'll continue running this after each day of crawling.