### PR TITLE
Skip malformed proxdiscover items

### DIFF
--- a/app/geo.py
+++ b/app/geo.py
@@ -24,6 +24,8 @@ def get_place_ids_in_radius(center, radius_km, cached_locations_table=None):
 
     place_ids_in_radius = set()
     for place_id, vals in location_table.items():
+        if (place_id.startswith("proxdiscover-")):
+            continue
         lat, lng = vals['l']
         coord = (lat, lng)
         if geofire.distance(center, coord) <= radius_km:


### PR DESCRIPTION
proxdiscover- places have an extra level of firebase hierarchy, skip these so the crawl_expand script still works.